### PR TITLE
L530 Color controlling problem fix.

### DIFF
--- a/src/platformL530Accessory.ts
+++ b/src/platformL530Accessory.ts
@@ -275,10 +275,10 @@ export class L530Accessory {
    */
   setHue(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     if(this.l530.getSysInfo().device_on){
-      this.l530.setColor(value as number, this.l530.getSysInfo().saturation).then((result) => {
+      this.l530.setColor(Math.round(value as number), this.l530.getSysInfo().saturation).then((result) => {
         if(result){
-          this.l530.getSysInfo().hue = value as number;
-          this.platform.log.debug('Set Characteristic Hue ->', value);
+          this.l530.getSysInfo().hue = Math.round(value as number);
+          this.platform.log.debug('Set Characteristic Hue ->', Math.round(value as number));
           this.platform.log.debug('With Characteristic Saturation ->', this.l530.getSysInfo().saturation);
   
           // you must call the callback function
@@ -324,10 +324,10 @@ export class L530Accessory {
    */
   setSaturation(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     if(this.l530.getSysInfo().device_on){
-      this.l530.setColor(this.l530.getSysInfo().hue, value as number).then((result) => {
+      this.l530.setColor(this.l530.getSysInfo().hue, Math.round(value as number)).then((result) => {
         if(result){
-          this.l530.getSysInfo().saturation = value as number;
-          this.platform.log.debug('Set Characteristic Saturation ->', value);
+          this.l530.getSysInfo().saturation = Math.round(value as number);
+          this.platform.log.debug('Set Characteristic Saturation ->', Math.round(value as number));
           this.platform.log.debug('With Characteristic Hue ->', this.l530.getSysInfo().hue);
   
           // you must call the callback function

--- a/src/utils/l530.ts
+++ b/src/utils/l530.ts
@@ -39,7 +39,7 @@ export default class L530 extends L510E {
               '"method": "set_device_info",'+
               '"params": {'+
                   '"hue": 0,' +
-                  '"saturation": 0,'
+                  '"saturation": 0,' +
                   '"color_temp": ' + roundedValue +
                   '},'+
                   '"requestTimeMils": ' + Math.round(Date.now() * 1000) + ''+
@@ -60,9 +60,9 @@ export default class L530 extends L510E {
     const payload = '{'+
               '"method": "set_device_info",'+
               '"params": {'+
-                  '"hue": ' + hue + ','+
+                  '"hue": ' + Math.round(hue) + ','+
                   '"color_temp": 0,' +
-                  '"saturation": ' + saturation +
+                  '"saturation": ' + Math.round(saturation) +
                   '},'+
                   '"requestTimeMils": ' + Math.round(Date.now() * 1000) + ''+
                   '};';

--- a/src/utils/l530.ts
+++ b/src/utils/l530.ts
@@ -38,6 +38,8 @@ export default class L530 extends L510E {
     const payload = '{'+
               '"method": "set_device_info",'+
               '"params": {'+
+                  '"hue": 0,' +
+                  '"saturation": 0,'
                   '"color_temp": ' + roundedValue +
                   '},'+
                   '"requestTimeMils": ' + Math.round(Date.now() * 1000) + ''+
@@ -59,6 +61,7 @@ export default class L530 extends L510E {
               '"method": "set_device_info",'+
               '"params": {'+
                   '"hue": ' + hue + ','+
+                  '"color_temp": 0,' +
                   '"saturation": ' + saturation +
                   '},'+
                   '"requestTimeMils": ' + Math.round(Date.now() * 1000) + ''+


### PR DESCRIPTION
L530 Color controlling problem fix.
when setting hue or saturation on the blub, plugin should set color_temp to 0 in order to set the color.
and non-integer value for hue, saturation is not allowed.