### PR TITLE
Added 'total' field in getEnergyUsage()

### DIFF
--- a/src/utils/p110.ts
+++ b/src/utils/p110.ts
@@ -28,10 +28,12 @@ export default class P110 extends P100 {
       if(response && response.result){
         this._consumption = {
           current: response.result.current_power / 1000,
+          total: response.result.today_energy / 1000,
         };
       } else{
         this._consumption = {
           current: 0,
+          total: 0,
         };
       }
      


### PR DESCRIPTION
This relates to Issue #33 (P110 warnings - power consumption related)

After examining the output of `getEnergyUsage()` of `PyP110` I saw that `today_energy` could be added as the (missing) `total` of `getEnergyUsage()` response in `p110.ts`.

This should solve the

```
This plugin generated a warning from the characteristic 'Total Consumption': characteristic value expected valid finite number and received "undefined" (undefined). See https://git.io/JtMGR for more info.
```

warning message in the Homebridge log that I reported.

I really tried to test this before creating the PR but it wasn't possible to install a fork in (I've got zero experience in Homebridge development).

Looking forward to any feedback! Thanks for your time.